### PR TITLE
pytest-astropy-header needs astropy

### DIFF
--- a/.github/workflows/bugbot_workflows.yml
+++ b/.github/workflows/bugbot_workflows.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools
-        python -m pip install PyGithub pytest-astropy-header pytest-remotedata
+        python -m pip install PyGithub pytest-remotedata
     # Run bot script.
     # TODO: For production, repo will call an external bugbot.
     - name: Bug bot

--- a/conftest.py
+++ b/conftest.py
@@ -1,23 +1,10 @@
-try:
-    from pytest_astropy_header.display import PYTEST_HEADER_MODULES
-except ImportError:
-    PYTEST_HEADER_MODULES = {}
+def pytest_report_header(config):
+    import os
 
-try:
-    from pytest_astropy_header.display import TESTED_VERSIONS
-except ImportError:
-    TESTED_VERSIONS = {}
+    deps = ['Package versions: ']
 
-
-def pytest_configure(config):
-    config.option.astropy_header = True
-
+    # Append dependency as needed.
     # https://github.com/PyGithub/PyGithub/issues/1600
-    # PYTEST_HEADER_MODULES['PyGithub'] = 'github'
+    deps.append('PyGitHub: stable')
 
-    PYTEST_HEADER_MODULES.pop('Pandas', None)
-    PYTEST_HEADER_MODULES.pop('Matplotlib', None)
-    PYTEST_HEADER_MODULES.pop('h5py', None)
-
-
-TESTED_VERSIONS['bugbot'] = 'dev'
+    return os.linesep.join(deps)


### PR DESCRIPTION
We'll just use basic [test report header](https://docs.pytest.org/en/stable/example/simple.html#adding-info-to-test-report-header).